### PR TITLE
Fix: restore Tailwind styles + global Inter font

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -3,11 +3,7 @@ import "./globals.css";
 import Header from "./components/Header";
 import { Inter } from "next/font/google";
 
-const font = Inter({
-  subsets: ["latin"],
-  variable: "--font-sans",
-  display: "swap",
-});
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: "Ctrl+Content • B2B Content Strategist",
@@ -17,8 +13,8 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en" className={font.variable}>
-      <body className="font-sans">
+    <html lang="en" className={inter.className}>
+      <body>
         <Header />
         {/* Centered, wide container using our CSS utilities */}
         <main className="container-pro section">{children}</main>

--- a/app/page.js
+++ b/app/page.js
@@ -113,11 +113,11 @@ export default function Home() {
     <>
       {/* HERO */}
       <section className="cc-hero cc-mb-24">
-        <div className="cc-container">
+        <div className="cc-container container mx-auto px-4">
           <div className="grid items-center gap-12 py-20 md:grid-cols-2 md:py-32">
             <div>
               <span className="cc-eyebrow">Ctrl+Content</span>
-              <h1 className="cc-h1 mt-2">AI content planning, minus the busywork</h1>
+              <h1 className="cc-h1 mt-2 text-slate-900">AI content planning, minus the busywork</h1>
               <p className="cc-lead mt-4">
                 Generate your entire content calendar and briefs in seconds.
               </p>

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ["tailwindcss", "autoprefixer"],
 };
 
 export default config;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./app/**/*.{js,jsx,ts,tsx}'],
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
- fix global layout to load Inter font and Tailwind globals
- broaden Tailwind and PostCSS configs for App Router
- add container proof classes in hero section
- drop placeholder screenshots for a code-only PR

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e1fc6143c8323aa925da033b0c37e