### PR TITLE
Build: add autoprefixer (fix Vercel build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "autoprefixer": "^10.4.20",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
+    "postcss": "^8.4.47",
     "tailwindcss": "^4"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,0 @@
-const config = {
-  plugins: ["tailwindcss", "autoprefixer"],
-};
-
-export default config;


### PR DESCRIPTION
## Summary
- add autoprefixer and postcss dev dependencies
- switch PostCSS config to CommonJS with explicit plugin order

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689e2b9e41a48323bf4bf7eeeafd74f5